### PR TITLE
Fix method trailer problem in Pharo 12

### DIFF
--- a/src/Hermes/HEInstaller.class.st
+++ b/src/Hermes/HEInstaller.class.st
@@ -217,7 +217,7 @@ HEInstaller >> rebuildMethod: aMethod into: aClass [
 
 	self flag: #pharo11. "If Pharo12 the management of the method trailer changed and the way to create a new method changed too."
 	newMethod := CompiledMethod
-		             newMethod: (SystemVersion current major > 12
+		             newMethod: (SystemVersion current major >= 12
 				              ifTrue: [ aMethod bytecode size + CompiledMethod trailerSize ]
 				              ifFalse: [ aMethod bytecode size ])
 		             header: (aMethod headerFor: extendedEnvironment).

--- a/src/Hermes/HEInstaller.class.st
+++ b/src/Hermes/HEInstaller.class.st
@@ -206,32 +206,32 @@ HEInstaller >> messageMethod: aHEMethod alreadyExistsIn: aClass [
 
 { #category : 'installing methods' }
 HEInstaller >> rebuildMethod: aMethod into: aClass [
+
 	| newMethod literalSpace extendedEnvironment |
-	
-	(self shouldBuildMethod: aMethod in: aClass) ifFalse: [ ^ self ].	
+	(self shouldBuildMethod: aMethod in: aClass) ifFalse: [ ^ self ].
 
 	extendedEnvironment := HEExtendedEnvironment new.
 	extendedEnvironment inner: environment.
 	extendedEnvironment newClass: aClass.
 	extendedEnvironment newSelector: aMethod name.
 
-	newMethod := CompiledMethod newMethod: aMethod bytecode size header: (aMethod headerFor: extendedEnvironment).
+	self flag: #pharo11. "If Pharo12 the management of the method trailer changed and the way to create a new method changed too."
+	newMethod := CompiledMethod
+		             newMethod: (SystemVersion current major > 12
+				              ifTrue: [ aMethod bytecode size + CompiledMethod trailerSize ]
+				              ifFalse: [ aMethod bytecode size ])
+		             header: (aMethod headerFor: extendedEnvironment).
 
 	extendedEnvironment newMethod: newMethod.
 
-	aMethod literals
-		doWithIndex:
-			[ :literal :idx | newMethod literalAt: idx put: (literal asLiteralIn: extendedEnvironment) ].
+	aMethod literals doWithIndex: [ :literal :idx | newMethod literalAt: idx put: (literal asLiteralIn: extendedEnvironment) ].
 
 	newMethod classBinding: aClass binding.
-	literalSpace := (aMethod literals size + 1) * Smalltalk wordSize.
+	literalSpace := aMethod literals size + 1 * Smalltalk wordSize.
 
 	aMethod bytecode doWithIndex: [ :e :idx | newMethod at: idx + literalSpace put: e ].
 
-	aClass
-		addAndClassifySelector: aMethod name
-		withMethod: newMethod
-		inProtocol: aMethod protocol
+	aClass addAndClassifySelector: aMethod name withMethod: newMethod inProtocol: aMethod protocol
 ]
 
 { #category : 'reporting undeclared' }


### PR DESCRIPTION
If Pharo 12 the management of the method trailer changed and this changes the way to instantiate a CompiledMethod. This change should be reflected in Hermes.

I have no idea how to test this :(